### PR TITLE
Reorder past events on gallery page

### DIFF
--- a/gallery/index.html
+++ b/gallery/index.html
@@ -134,6 +134,33 @@
   
       <ul class="md:sticky top-[10px] p-[10px] rounded-md w-[fit-content] bg-white z-[99] left-0 wow fadeInLeft flex flex-wrap text-sm font-medium text-center text-gray-500 dark:text-gray-400">
         <li class="me-2">
+            <a href="#gabrielino_club_rush" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Gabrielino Club Rush</a>
+        </li>
+        <li class="me-2">
+            <a href="#walnut_club_rush" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Walnut Club Rush</a>
+        </li>
+        <li class="me-2">
+            <a href="#eastlake_cards" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Eastlake Card Making</a>
+        </li>
+        <li class="me-2">
+            <a href="#utsav_mela" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Utsav Mela</a>
+        </li>
+        <li class="me-2">
+            <a href="#food_fund" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Food Fundraiser</a>
+        </li>
+        <li class="me-2">
+            <a href="#jl_letters" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Letter Writing</a>
+        </li>
+        <li class="me-2">
+            <a href="#james_logan_club_fair" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">James Logan Club Fair</a>
+        </li>
+        <li class="me-2">
+            <a href="#nash_fair_24" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">NASH Club Fair</a>
+        </li>
+        <li class="me-2">
+            <a href="#philly_cards" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Card Making</a>
+        </li>
+        <li class="me-2">
             <a href="#pghacs24" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Pgh ACS</a>
         </li>
         <li class="me-2">
@@ -195,33 +222,6 @@
         </li>
         <li class="me-2">
             <a href="#steam" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">STEAM Symposium</a>
-        </li>
-        <li class="me-2">
-            <a href="#philly_cards" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Card Making</a>
-        </li>
-        <li class="me-2">
-            <a href="#nash_fair_24" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">NASH Club Fair</a>
-        </li>
-        <li class="me-2">
-            <a href="#james_logan_club_fair" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">James Logan Club Fair</a>
-        </li>
-        <li class="me-2">
-            <a href="#jl_letters" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Letter Writing</a>
-        </li>
-        <li class="me-2">
-            <a href="#food_fund" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Food Fundraiser</a>
-        </li>
-        <li class="me-2">
-            <a href="#utsav_mela" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Utsav Mela</a>
-        </li>
-        <li class="me-2">
-            <a href="#eastlake_cards" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Eastlake Card Making</a>
-        </li>
-        <li class="me-2">
-            <a href="#walnut_club_rush" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Walnut Club Rush</a>
-        </li>
-        <li class="me-2">
-            <a href="#gabrielino_club_rush" class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white">Gabrielino Club Rush</a>
         </li>
       </ul>
 


### PR DESCRIPTION
Move specified sections to the top of the past events page in the following order: `gabrielino_club_rush`, `walnut_club_rush`, `eastlake_cards`, `utsav_mela`, `food_fund`, `jl_letters`, `james_logan_club_fair`, `nash_fair_24`, `philly_cards`.

* Move `gabrielino_club_rush` section to the top of the page.
* Move `walnut_club_rush` section after `gabrielino_club_rush`.
* Move `eastlake_cards` section after `walnut_club_rush`.
* Move `utsav_mela` section after `eastlake_cards`.
* Move `food_fund` section after `utsav_mela`.
* Move `jl_letters` section after `food_fund`.
* Move `james_logan_club_fair` section after `jl_letters`.
* Move `nash_fair_24` section after `james_logan_club_fair`.
* Move `philly_cards` section after `nash_fair_24`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CoolCoderSJ/CARE/pull/2?shareId=63e95f48-f7b8-43f8-97c0-72a4adb2f1b9).